### PR TITLE
Submit setupell task to patchwork

### DIFF
--- a/config.main.ini
+++ b/config.main.ini
@@ -56,6 +56,7 @@ submit_pw = yes
 
 [setupell]
 install = no
+submit_pw = yes
 
 ;
 ; build options

--- a/config.musl.ini
+++ b/config.musl.ini
@@ -50,6 +50,7 @@ enable = no
 
 [setupell]
 install = no
+submit_pw = yes
 
 ;
 ; build options


### PR DESCRIPTION
If ELL fails to build this should cause the CI to fail. Generally this should only happen if the CI is triggered from an ELL patch which breaks the build, or if upstream ELL is broken.